### PR TITLE
Add serverless config and task handlers

### DIFF
--- a/infra/serverless.yml
+++ b/infra/serverless.yml
@@ -1,0 +1,30 @@
+service: serverless-task-api
+provider:
+  name: aws
+  runtime: nodejs16.x
+functions:
+  getTasks:
+    handler: src/handler.getTasks
+    events:
+      - http:
+          path: tasks
+          method: get
+  createTask:
+    handler: src/handler.createTask
+    events:
+      - http:
+          path: tasks
+          method: post
+resources:
+  Resources:
+    TasksDynamoDbTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: Tasks
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,8 +1,40 @@
 'use strict';
 
-module.exports.hello = async (event) => {
+const AWS = require('aws-sdk');
+const { v4: uuidv4 } = require('uuid');
+
+const TABLE_NAME = 'Tasks';
+const docClient = new AWS.DynamoDB.DocumentClient();
+
+module.exports.getTasks = async () => {
+  const data = await docClient.scan({ TableName: TABLE_NAME }).promise();
   return {
     statusCode: 200,
-    body: JSON.stringify({ message: 'Hello from serverless-task-api' }),
+    body: JSON.stringify(data.Items),
+  };
+};
+
+module.exports.createTask = async (event) => {
+  let body;
+  try {
+    body = JSON.parse(event.body);
+  } catch (err) {
+    return { statusCode: 400 };
+  }
+
+  if (!body || typeof body.title !== 'string') {
+    return { statusCode: 400 };
+  }
+
+  const item = {
+    id: uuidv4(),
+    title: body.title,
+  };
+
+  await docClient.put({ TableName: TABLE_NAME, Item: item }).promise();
+
+  return {
+    statusCode: 201,
+    body: JSON.stringify(item),
   };
 };


### PR DESCRIPTION
## Summary
- add `infra/serverless.yml` with Serverless Framework configuration
- implement DynamoDB-powered handlers `getTasks` and `createTask`

## Testing
- `npm test` *(fails: `jest` not found)*