### PR TITLE
Add Node.js CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
## Summary
- add CI config to run Node.js tests on pushes to `main`

## Testing
- `npm test` *(fails: connect EHOSTUNREACH)*